### PR TITLE
fix: email encoding should replace ALL allowed characters

### DIFF
--- a/src/lib/helpers/encode-email.ts
+++ b/src/lib/helpers/encode-email.ts
@@ -1,15 +1,18 @@
 // Encode the email address to prevent XSS but leave in valid
 // characters, following this official spec:
 // http://en.wikipedia.org/wiki/Email_address#Syntax
+//
+// We have to replace all the possible characters.
+// that's why we use a regex with a global flag.
 function encodeEmail(email: string): string {
   const result = encodeURI(email)
-    .replace('%20', ' ')
-    .replace('%25', '%')
-    .replace('%5E', '^')
-    .replace('%60', '`')
-    .replace('%7B', '{')
-    .replace('%7C', '|')
-    .replace('%7D', '}');
+    .replace(/%20/g, ' ')
+    .replace(/%25/g, '%')
+    .replace(/%5E/g, '^')
+    .replace(/%60/g, '`')
+    .replace(/%7B/g, '{')
+    .replace(/%7C/g, '|')
+    .replace(/%7D/g, '}');
   return result;
 }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -291,5 +291,33 @@ describe('mailSpellChecker', () => {
       const result = encodeEmail(" g1!#$%&'*+-/=?^_`{|}@gmai.com");
       expect(result).toEqual(" g1!#$%&'*+-/=?^_`{|}@gmai.com");
     });
+
+    it('does not encode empty spaces', function () {
+      expect(encodeEmail('   postbox@com   ')).toEqual('   postbox@com   ');
+    });
+
+    it('does not encode percentage', function () {
+      expect(encodeEmail('%%%postbox%@%com%')).toEqual('%%%postbox%@%com%');
+    });
+
+    it('does not encode caret', function () {
+      expect(encodeEmail('^^^postbox^^^@^^^com^^^')).toEqual(
+        '^^^postbox^^^@^^^com^^^'
+      );
+    });
+
+    it('does not encode backtick', function () {
+      expect(encodeEmail('`` hola@jorge.com')).toEqual('`` hola@jorge.com');
+    });
+
+    it('does not encode brackets', function () {
+      expect(encodeEmail('{{hola@jorge.com}}')).toEqual('{{hola@jorge.com}}');
+    });
+
+    it('does not encode pipe', function () {
+      expect(encodeEmail('|||hola|||@jorge.com')).toEqual(
+        '|||hola|||@jorge.com'
+      );
+    });
   });
 });


### PR DESCRIPTION
### Bug description

This is a historical bug that [mailcheck library](https://github.com/mailcheck/mailcheck) (the one we're replacing) has had since the beginning. 

mailcheck encoded the email to prevent XSS, but kept some characters unencoded to be compliant with [`RFC 5322`](https://en.wikipedia.org/wiki/Email_address#Syntax). However, their function to replace characters only replaced the first character, since they forgot to run the spaces globally.

I noticed this while performing some tests of this library in [our main application for ZooTools](https://zootools.co/), an email with spaces like `      jorge@test.com` was returned encoded

![Screen Shot 2022-10-22 at 4 32 35 PM](https://user-images.githubusercontent.com/7242959/197344764-d12368b2-9330-4edc-ba8b-7eca00415f8c.png)

![Uploading Screen Shot 2022-10-22 at 4.47.38 PM.png…]()

### Description of change

<a href="https://www.loom.com/share/284ab5fe9ecf4475a07ed29060369398">
    <img src="https://user-images.githubusercontent.com/7242959/197345579-18b2dff8-68c7-4b2b-8cfa-9b9c4906e129.png" />
</a>

I updated the regex to be run glob ally across every character. This will take a bit longer to validate the email, but it's blazing fast anyways and it's only run once when the email is being passed.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)