### PR TITLE
feat: replace `trim` by the #1 most popular trim library

### DIFF
--- a/src/lib/helpers/trim.ts
+++ b/src/lib/helpers/trim.ts
@@ -1,6 +1,30 @@
+const WHITESPACE_PATTERN = /\s/;
+
+/**
+ * Just in case a browser doesn't support .trim
+ * Copied from https://github.com/Trott/trim
+ * Credits to them
+ */
 function trim(str: string): string {
-  // trim() not exist in old IE!
-  return str.replace(/^\s*/, '').replace(/\s*$/, '');
+  if (str.trim) {
+    return str.trim();
+  }
+  return right(left(str));
+}
+
+function left(str: string): string {
+  if (str.trimLeft) return str.trimLeft();
+
+  return str.replace(/^\s\s*/, '');
+}
+
+function right(str: string): string {
+  if (str.trimRight) return str.trimRight();
+
+  let i = str.length;
+  while (WHITESPACE_PATTERN.test(str.charAt(--i)));
+
+  return str.slice(0, i + 1);
 }
 
 export default trim;


### PR DESCRIPTION
### Description of change

We inherit a trim function from `mailcheck` (an outdated library that we rewrote in TypeScript).

It doesn't make sense to use it versus `trim` a well tested and [#1 trim library in NPM](https://www.npmjs.com/package/trim) ecosystem right now with 5M weekly downloads.

In order to not create external dependencies, I copy paste their trim function.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
