### PR TITLE
refactor: remove google.com from TLDs

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -32,7 +32,6 @@ const POPULAR_DOMAINS = [
   'rogers.com',
   'verizon.net',
   'rocketmail.com',
-  'google.com',
   'optonline.net',
   'sbcglobal.net',
   // aol


### PR DESCRIPTION
### Description of change

As per this PR on mailcheck, removing google.com since it's a domain used by employees but you can't buy that email address: https://github.com/mailcheck/mailcheck/issues/177