### PR TITLE
refactor: remove GMX from second level domains

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -129,7 +129,7 @@ const DEFAULT_CONFIG = {
   domains: POPULAR_DOMAINS,
 
   secondLevelThreshold: 2,
-  secondLevelDomains: ['yahoo', 'hotmail', 'mail', 'live', 'outlook', 'gmx'],
+  secondLevelDomains: ['yahoo', 'hotmail', 'mail', 'live', 'outlook'],
 
   topLevelThreshold: 2,
   topLevelDomains: POPULAR_TLDS,


### PR DESCRIPTION
### Description of change

By default we should not include GMX as a second-level domain:

1) It's a low-used email provider (11M users vs. 1.5Billion from Gmail or other services)
2) test@gmal. -> got suggested gmx instead of Gmail.


If your application heavily relies on GMX, then pass it as a configuration parameter in the second top level domains. But it doesn't make sense to have this as a default.


![Screen Shot 2022-10-23 at 4 03 39 PM](https://user-images.githubusercontent.com/7242959/197396626-841107fd-3598-49aa-8fa2-c1fbf548b550.png)


### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
