### PR TITLE
Export POPULAR_TLDS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import run from './lib/run';
-import { POPULAR_DOMAINS } from './lib/config';
+import { POPULAR_DOMAINS, POPULAR_TLDS } from './lib/config';
 
 const MailSpellChecker = {
   run,
   POPULAR_DOMAINS,
+  POPULAR_TLDS,
 };
 
-export { run, POPULAR_DOMAINS };
+export { run, POPULAR_DOMAINS, POPULAR_TLDS };
 export default MailSpellChecker;


### PR DESCRIPTION
Also export `POPULAR_TLDS` just as `POPULAR_DOMAINS` is exported, making it possible to add TLDs to the run config as;

```
emailSpellChecker.run({
  topLevelDomains: [...emailSpellChecker.POPULAR_TLDS, 'com.au', 'ru'], // extends existing TLDs
});
```