### PR TITLE
Add mac.com and .tv

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -38,6 +38,7 @@ const POPULAR_DOMAINS = [
   'aol.com',
   'aim.com',
   'me.com',
+  'mac.com',
   'mailw.com',
   'btinternet.com',
   'charter.net',

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -146,6 +146,7 @@ const POPULAR_TLDS = [
   'software',
   'to',
   'tech',
+  'tv',
 ];
 
 const DEFAULT_CONFIG = {


### PR DESCRIPTION
### Description of change

Add mac.com popular domains and .tv to popular tlds, to fix false positives for both.

Fixes #25 
Fixes #26 

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

### Notes

I am submitting both fixes at once, but I could separate them, if you'd like. I was planning on adding tests, but I realized that there weren't any tests for false positives, so I didn't add a section for that. Again, I could if you want that. Thanks!
